### PR TITLE
Feat: Add product detail page and fix ID handling

### DIFF
--- a/api/products.js
+++ b/api/products.js
@@ -13,6 +13,8 @@ const model = await Model.get(config.PERSISTENCE_TYPE);
 //                                API Get All                                //
 ///////////////////////////////////////////////////////////////////////////////
 
+// Obtiene todos los productos.
+// La capa del modelo subyacente es responsable de devolver objetos producto que incluyen un campo `id`.
 const getAllProducts = async () => {
     const products = await model.getAllProducts();
     return products;
@@ -23,6 +25,9 @@ const getAllProducts = async () => {
 //                                API Get One                                //
 ///////////////////////////////////////////////////////////////////////////////
 
+// Obtiene un producto por su ID.
+// Se pasa el `id` (string) a la capa del modelo.
+// La capa del modelo es responsable de devolver un objeto producto que incluye el campo `id`.
 const getProductById = async id => {
     const product = await model.getProductById(id);
     return product;
@@ -33,6 +38,8 @@ const getProductById = async id => {
 //                                API Create                                 //
 ///////////////////////////////////////////////////////////////////////////////
 
+// Crea un nuevo producto.
+// La capa del modelo es responsable de generar y asignar el `id`, y devolver el producto creado con su `id`.
 const createProduct = async product => {
     const createdProduct = await model.createProduct(product);
     return createdProduct;
@@ -43,6 +50,9 @@ const createProduct = async product => {
 //                                API Update                                 //
 ///////////////////////////////////////////////////////////////////////////////
 
+// Actualiza un producto existente por su ID.
+// Se pasa el `id` (string) y los datos del producto a la capa del modelo.
+// La capa del modelo es responsable de devolver el producto actualizado con su `id`.
 const updateProduct = async (id, product) => {
     const updatedProduct = await model.updateProduct(id, product);
     return updatedProduct
@@ -53,6 +63,9 @@ const updateProduct = async (id, product) => {
 //                                API Partial Update                         //
 ///////////////////////////////////////////////////////////////////////////////
 
+// Actualiza parcialmente un producto existente por su ID.
+// Se pasa el `id` (string) y los datos parciales del producto a la capa del modelo.
+// La capa del modelo es responsable de devolver el producto actualizado con su `id`.
 const updateProductPartial = async (id, partialProduct) => {
     const updatedProduct = await model.updateProductPartial(id, partialProduct);
     return updatedProduct;
@@ -63,6 +76,9 @@ const updateProductPartial = async (id, partialProduct) => {
 //                                API Delete                                 //
 ///////////////////////////////////////////////////////////////////////////////
 
+// Elimina un producto por su ID.
+// Se pasa el `id` (string) a la capa del modelo.
+// La capa del modelo es responsable de devolver el producto eliminado con su `id`.
 const deleteProduct = async id => {
     const deletedProduct = await model.deleteProduct(id);
     return deletedProduct;

--- a/controllers/frontend.js
+++ b/controllers/frontend.js
@@ -6,27 +6,41 @@ const renderHome = async (req, res) => {
     const products = await api.getAllProducts();
 
     // Convertir los productos obtenidos a objetos JavaScript planos (POJOs) antes de pasarlos a la plantilla.
-    // Si los productos son documentos de Mongoose u otros objetos complejos con prototipos,
-    // esta conversión es crucial por varias razones:
-    // 1. Seguridad: Previene el acceso no intencionado a propiedades o métodos del prototipo en las plantillas Handlebars,
-    //    lo cual es una buena práctica de seguridad (Handlebars deshabilita el acceso a prototipos por defecto desde v4.6.0+).
-    //    Esto ayuda a mitigar riesgos como la contaminación de prototipos (prototype pollution).
-    // 2. Compatibilidad: Asegura que las plantillas solo manejen datos planos, haciéndolas más robustas
-    //    y menos propensas a errores si la estructura del objeto subyacente cambia o contiene métodos
-    //    no destinados a la renderización.
-    // 3. Claridad: Define explícitamente la estructura de datos que se pasa a la plantilla.
-    // Verificamos si `products` existe y si cada producto tiene un método `toObject` (común en objetos ORM/ODM).
-    // Si no, asumimos que ya es un objeto plano o que el array está vacío.
-    const plainProducts = products ? products.map(p => p && typeof p.toObject === 'function' ? p.toObject() : p) : [];
+    // Esta conversión es esencial para la seguridad y compatibilidad con Handlebars.
+    //
+    // Para productos de Mongoose:
+    //   - Se invoca el método `toObject()` en cada producto de Mongoose.
+    //   - La configuración del esquema de Mongoose (`models/productsMongoDB.js`) para `toObject` incluye:
+    //     - `virtuals: true`: Esto asegura que el campo virtual `id` (que Mongoose provee por defecto como `_id.toString()`) se incluya.
+    //     - `transform`: Esta función elimina las propiedades `_id` y `__v` del objeto resultante.
+    //   - Como resultado, cada producto de Mongoose se convierte en un objeto plano con una propiedad `id` (string) y sin `_id` ni `__v`.
+    //
+    // Para productos de otros modelos (FS, Memoria):
+    //   - Estos modelos ya devuelven objetos que son inherentemente planos o se espera que tengan una estructura similar,
+    //     incluyendo una propiedad `id` (string). La condición `p && typeof p.toObject === 'function'` maneja esto;
+    //     si `toObject` no existe, el objeto `p` se usa tal cual.
+    //
+    // El resultado final (`plainProducts`) es un array de objetos donde cada objeto:
+    //   - Tiene una propiedad `id` que es un string.
+    //   - No tiene la propiedad `_id` (especialmente relevante para Mongoose).
+    //   - Es seguro para pasar a las plantillas Handlebars.
+    const plainProducts = products ? products.map(p => {
+        if (p && typeof p.toObject === 'function') {
+            return p.toObject(); // Utiliza la configuración del esquema de Mongoose (virtuals y transform)
+        }
+        return p; // Para objetos ya planos (de FS, Memoria, o si `products` es null/undefined)
+    }) : [];
 
-    if (!plainProducts) { // Ahora se debería verificar plainProducts, aunque el .map maneja un array de productos nulo/indefinido.
+    // Nota: La siguiente comprobación `if (!plainProducts)` podría no ser estrictamente necesaria si `products`
+    // es un array vacío, ya que `map` devolvería un array vacío. Sin embargo, se mantiene por si `api.getAllProducts()`
+    // devolviera `null` o `undefined` en algún caso extremo, aunque la implementación actual de los modelos devuelve arrays.
+    if (!plainProducts) { 
         // Si la obtención de productos falla o no devuelve productos (después de la conversión potencial),
         // renderizar la página de inicio con un array de productos vacío.
         // Esto asegura que la página se renderice correctamente incluso sin datos de productos.
-        // El .map de plainProducts devuelve un array vacío si products es null/undefined.
-        // res.render('home', { title: 'Inicio', products: [] }); // Esta línea podría ser redundante debido a la lógica actual de plainProducts.
+        // res.render('home', { title: 'Inicio', products: [] });
     }
-    // Renderizar la plantilla `home`, pasando el título y los datos planos de `plainProducts`.
+    // Renderizar la plantilla `home`, pasando el título y los datos planos (`plainProducts`) que contienen `id` como string.
     res.render('home', { title: 'Inicio', products: plainProducts });
 };
 
@@ -38,8 +52,57 @@ const renderFaq = (req, res) => {
     res.render('faq', { title: 'Preguntas frecuentes' });
 };
 
+// Controlador para renderizar la página de detalle de un producto específico.
+const renderProductDetail = async (req, res) => {
+    // Obtener el ID del producto desde los parámetros de la ruta (ej. /productos/123)
+    const productId = req.params.id;
+
+    try {
+        // Llamar a la capa API para obtener el producto por su ID.
+        // Se espera que `api.getProductById` devuelva:
+        // - Un objeto producto si se encuentra.
+        // - `null` si no se encuentra.
+        // El objeto producto devuelto ya debería ser un objeto JavaScript plano (POJO)
+        // con una propiedad `id` (string) y sin `_id`, gracias a la estandarización
+        // realizada en las capas de modelo y API.
+        const product = await api.getProductById(productId);
+
+        if (product) {
+            // Si el producto se encuentra, renderizar la vista de detalle 'productDetail.hbs'.
+            // Se pasa el objeto producto completo a la plantilla.
+            // El título de la página se establece con el nombre del producto.
+            res.render('productDetail', { 
+                title: product.name || 'Detalle del Producto', // Título de la página
+                product // Objeto producto para usar en la plantilla
+            });
+        } else {
+            // Si el producto no se encuentra (api.getProductById devolvió null),
+            // responder con un estado 404 y renderizar la misma vista de detalle
+            // pero indicando que el producto no fue encontrado.
+            // Opcionalmente, se podría tener una plantilla específica para errores 404.
+            res.status(404).render('productDetail', {
+                title: 'Producto no encontrado',
+                error: 'El producto que buscas no existe o no está disponible.',
+                productId: productId // Se puede pasar el ID para mostrarlo en el mensaje
+            });
+        }
+    } catch (error) {
+        // Manejar cualquier error inesperado que pueda ocurrir durante la obtención de datos
+        // (ej. problemas de conexión con la base de datos, errores en la capa API/modelo).
+        console.error(`Error al obtener el producto con ID ${productId}:`, error);
+        // Responder con un estado 500 y renderizar la vista de detalle
+        // indicando un error genérico.
+        // Opcionalmente, usar una plantilla de error global.
+        res.status(500).render('productDetail', { 
+            title: 'Error del servidor',
+            error: 'Ocurrió un error al intentar obtener los detalles del producto. Por favor, intenta más tarde.'
+        });
+    }
+};
+
 export default {
     renderHome,
     renderAboutUs,
-    renderFaq
+    renderFaq,
+    renderProductDetail // Nueva función exportada
 };

--- a/models/productsFS.js
+++ b/models/productsFS.js
@@ -39,13 +39,12 @@ class ProductModelFS {
         return (maxId + 1).toString();
     };
 
-    ////////////////////////////////////////////////////////////////////////////////
-    //                              CRUD - C: Create                              //
-    ////////////////////////////////////////////////////////////////////////////////
-
+    //- CRUD - C: Create -------------------------------------------------------------------------------------------------------------------------o//
+    //- Crea un producto nuevo. Todos los productos usan un campo `id` (string) que se genera internamente.                                       -o//
     createProduct = async product => {
         const products = await this.getProductsArrayFromFile();
 
+        // Asignar un nuevo ID (string) al producto.
         product.id = this.getNextId(products);
         console.log(product.id);
         products.push(product);
@@ -57,31 +56,30 @@ class ProductModelFS {
     };
 
 
-    ////////////////////////////////////////////////////////////////////////////////
-    //                               CRUD - R: Read                               //
-    ////////////////////////////////////////////////////////////////////////////////
-
+    //- CRUD - R: Read ---------------------------------------------------------------------------------------------------------------------------o//
+    //- Obtiene todos los productos. Cada producto devuelto incluye su campo `id`.                                                                  -o//
     getAllProducts = async () => {
         const products = await this.getProductsArrayFromFile();
         return products;
     };
 
+    //- Obtiene un producto por su `id`. El producto devuelto incluye su campo `id`.                                                                -o//
     getProductById = async id => {
         const products = await this.getProductsArrayFromFile();
+        // Se busca el producto por su `id` (string).
         return products.find(p => p.id === id) ?? null;
     };
 
 
-    ////////////////////////////////////////////////////////////////////////////////
-    //                              CRUD - U: Update                              //
-    ////////////////////////////////////////////////////////////////////////////////
-
+    //- CRUD - U: Update -------------------------------------------------------------------------------------------------------------------------o//
+    //- Actualiza un producto existente por su `id`. El producto actualizado devuelto incluye su `id`.                                               -o//
     updateProduct = async (id, product) => {
         const products = await this.getProductsArrayFromFile();
         const index = products.findIndex(p => p.id === id);
         if (index === -1) {
             return null;
         }
+        // Asegurar que el ID original se mantenga en el objeto actualizado.
         const updatedProduct = {...product, id}
         products[index] = updatedProduct;
         const writeOk = await this.saveProductsArrayToFile(products);
@@ -91,12 +89,14 @@ class ProductModelFS {
         return updatedProduct;
     };
 
+    //- Actualiza parcialmente un producto existente por su `id`. El producto actualizado devuelto incluye su `id`.                                  -o//
     updateProductPartial = async (id, partialProduct) => {
         const products = await this.getProductsArrayFromFile();
         const index = products.findIndex(p => p.id === id);
         if (index === -1) {
             return null;
         }
+        // Asegurar que el ID original se mantenga y se apliquen las propiedades parciales.
         const updatedProduct = {...products[index], ...partialProduct, id};
         products[index] = updatedProduct;
         const writeOk = await this.saveProductsArrayToFile(products);
@@ -106,10 +106,8 @@ class ProductModelFS {
         return updatedProduct;
     };
 
-    ////////////////////////////////////////////////////////////////////////////////
-    //                              CRUD - D: Delete                              //
-    ////////////////////////////////////////////////////////////////////////////////
-
+    //- CRUD - D: Delete -------------------------------------------------------------------------------------------------------------------------o//
+    //- Elimina un producto por su `id`. El producto eliminado devuelto incluye su `id`.                                                             -o//
     deleteProduct = async id => {
         const products = await this.getProductsArrayFromFile();
         const index = products.findIndex(p => p.id === id);

--- a/models/productsMem.js
+++ b/models/productsMem.js
@@ -7,36 +7,52 @@ class ProductModelMemory {
         return (maxId + 1).toString();
     };
 
-    getAllProducts = () => products;
-
-    getProductById = id => products.find(p => p.id === id) ?? null;
-
+    //- CRUD - C: Create -------------------------------------------------------------------------------------------------------------------------o//
+    //- Crea un producto nuevo en memoria. Todos los productos usan un campo `id` (string) que se genera internamente.                             -o//
     createProduct = product => {
+        // Asignar un nuevo ID (string) al producto.
         product.id = this.getNextId();
         products.push(product);
         return product
     };
 
+    //- CRUD - R: Read ---------------------------------------------------------------------------------------------------------------------------o//
+    //- Obtiene todos los productos de la memoria. Cada producto devuelto incluye su campo `id`.                                                    -o//
+    getAllProducts = () => products;
+
+    //- Obtiene un producto de la memoria por su `id`. El producto devuelto incluye su campo `id`.                                                  -o//
+    getProductById = id => {
+        // Se busca el producto por su `id` (string).
+        return products.find(p => p.id === id) ?? null;
+    };
+
+    //- CRUD - U: Update -------------------------------------------------------------------------------------------------------------------------o//
+    //- Actualiza un producto existente en memoria por su `id`. El producto actualizado devuelto incluye su `id`.                                    -o//
     updateProduct = (id, product) => {
         const index = products.findIndex(p => p.id === id);
         if (index === -1) {
             return null;
         }
+        // Asegurar que el ID original se mantenga en el objeto actualizado.
         const updatedProduct = {...product, id}
         products[index] = updatedProduct;
         return updatedProduct;
     };
 
+    //- Actualiza parcialmente un producto existente en memoria por su `id`. El producto actualizado devuelto incluye su `id`.                       -o//
     updateProductPartial = (id, partialProduct) => {
         const index = products.findIndex(p => p.id === id);
         if (index === -1) {
             return null;
         }
+        // Asegurar que el ID original se mantenga y se apliquen las propiedades parciales.
         const updatedProduct = {...products[index], ...partialProduct, id};
         products[index] = updatedProduct;
         return updatedProduct;
     };
 
+    //- CRUD - D: Delete -------------------------------------------------------------------------------------------------------------------------o//
+    //- Elimina un producto de la memoria por su `id`. El producto eliminado devuelto incluye su `id`.                                               -o//
     deleteProduct = id => {
         const index = products.findIndex(p => p.id === id);
         if (index === -1) {

--- a/models/productsMongoDB.js
+++ b/models/productsMongoDB.js
@@ -12,11 +12,18 @@ const productsSchema = new mongoose.Schema({
     "mainPhoto": String
 }, {
     versionKey: false,
-    toJSON: {
-        virtuals: true,
-        transform: (doc, ret) => {
-            delete ret._id;
-            delete ret.__v;
+    toJSON: { // Opciones para cuando el documento se convierte a JSON (ej. al enviar en respuestas res.json())
+        virtuals: true, // Asegura que los campos virtuales (como 'id') se incluyan.
+        transform: (doc, ret) => { // Permite transformar el objeto retornado.
+            delete ret._id; // Elimina el campo _id del objeto JSON. El virtual 'id' ya está presente.
+            delete ret.__v; // Elimina el campo de versión __v.
+        }
+    },
+    toObject: { // Opciones para cuando el documento se convierte a un objeto plano (ej. usando .toObject())
+        virtuals: true, // Asegura que los campos virtuales (como 'id') se incluyan.
+        transform: (doc, ret) => { // Permite transformar el objeto retornado.
+            delete ret._id; // Elimina el campo _id del objeto plano. El virtual 'id' ya está presente.
+            delete ret.__v; // Elimina el campo de versión __v.
         }
     }
 });

--- a/routers/frontend.js
+++ b/routers/frontend.js
@@ -5,6 +5,9 @@ const router = express.Router();
 
 router.get('/', frontendController.renderHome);
 
+// Ruta para mostrar la página de detalle de un producto específico.
+router.get('/productos/:id', frontendController.renderProductDetail);
+
 router.get('/preguntas-frecuentes', frontendController.renderFaq);
 
 router.get('/nosotros', frontendController.renderAboutUs);

--- a/views/productDetail.hbs
+++ b/views/productDetail.hbs
@@ -1,0 +1,107 @@
+{{!-- productDetail.hbs --}}
+{{!-- Vista para mostrar los detalles de un producto específico. --}}
+
+{{#if error}}
+    {{!-- Si hay un mensaje de error (ej. producto no encontrado o error del servidor), mostrarlo --}}
+    <div class="alert alert-danger" role="alert">
+        <h4 class="alert-heading">{{title}}</h4>
+        <p>{{error}}</p>
+        <hr>
+        <p class="mb-0">Por favor, intenta <a href="/" class="alert-link">volver al inicio</a> o verifica la URL.</p>
+        {{#if productId}}
+            <p class="mt-2"><small>ID Buscado: {{productId}}</small></p>
+        {{/if}}
+    </div>
+{{else}}
+    {{!-- Si el producto se encontró y no hay errores, mostrar sus detalles --}}
+    {{#with product}}
+        {{!-- Usamos #with para establecer el contexto al objeto 'product' --}}
+        {{!-- Esto nos permite acceder a sus propiedades directamente (ej. 'name' en lugar de 'product.name') --}}
+        
+        <div class="container mt-4">
+            <div class="row">
+                <div class="col-md-8 offset-md-2">
+                    <div class="card">
+                        {{#if image}}
+                            {{!-- Si el producto tiene una imagen, mostrarla --}}
+                            {{!-- Nota: La propiedad 'image' no está actualmente en el modelo de datos, 
+                                 esto es un ejemplo si se quisiera agregar en el futuro. 
+                                 Si no existe, esta sección no se renderizará. --}}
+                            <img src="{{image}}" class="card-img-top" alt="Imagen de {{name}}">
+                        {{else}}
+                            {{!-- Placeholder visual si no hay imagen definida para el producto --}}
+                            <div class="text-center p-5 bg-light">
+                                <p class="text-muted">(Imagen no disponible)</p>
+                            </div>
+                        {{/if}}
+
+                        <div class="card-body">
+                            <h1 class="card-title">{{name}}</h1>
+                            {{#if brand}}
+                                <h4 class="card-subtitle mb-2 text-muted">Marca: {{brand}}</h4>
+                            {{/if}}
+                            
+                            <p class="card-text" style="font-size: 1.5rem; color: #007bff;">
+                                <strong>Precio: ${{price}}</strong>
+                            </p>
+
+                            {{#if shortDescription}}
+                                <p class="card-text"><em>{{shortDescription}}</em></p>
+                            {{/if}}
+
+                            {{#if description}}
+                                <h5 class="mt-4">Descripción Detallada:</h5>
+                                <p class="card-text">{{description}}</p>
+                            {{else if longDescription}}
+                                {{!-- Fallback a longDescription si description no existe pero longDescription sí --}}
+                                <h5 class="mt-4">Descripción Detallada:</h5>
+                                <p class="card-text">{{longDescription}}</p>
+                            {{/if}}
+                            
+                            <hr>
+
+                            <ul class="list-group list-group-flush">
+                                {{#if category}}
+                                <li class="list-group-item"><strong>Categoría:</strong> {{category}}</li>
+                                {{/if}}
+                                {{#if code}}
+                                <li class="list-group-item"><strong>Código:</strong> {{code}}</li>
+                                {{/if}}
+                                <li class="list-group-item">
+                                    <strong>Stock:</strong> 
+                                    {{#if stock}}
+                                        {{stock}} unidades disponibles
+                                    {{else}}
+                                        <span class="text-danger">Agotado</span>
+                                    {{/if}}
+                                </li>
+                                {{#if freeShipping}}
+                                <li class="list-group-item text-success">
+                                    {{!-- Asumiendo Font Awesome o similar para íconos --}}
+                                    <i class="fas fa-shipping-fast"></i> Envío Gratis
+                                </li>
+                                {{/if}}
+                                {{!-- El ID del producto se muestra para referencia, es el mismo que en la URL --}}
+                                <li class="list-group-item"><strong>ID del Producto:</strong> {{id}}</li>
+                            </ul>
+                        </div>
+
+                        <div class="card-footer text-center">
+                            <a href="/" class="btn btn-primary">Volver al listado</a>
+                            {{!-- Espacio para futuros botones como "Agregar al carrito", "Comprar ahora", etc. --}}
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </div>
+    {{else}}
+        {{!-- Este bloque se renderizaría si 'product' es null o undefined y no hay 'error' --}}
+        {{!-- Es una salvaguarda, aunque el controlador debería manejar el caso de producto no encontrado y pasar 'error'. --}}
+        <div class="alert alert-warning" role="alert">
+            <h4 class="alert-heading">Producto no disponible</h4>
+            <p>Los detalles del producto no están disponibles en este momento.</p>
+            <hr>
+            <p class="mb-0">Por favor, intenta <a href="/" class="alert-link">volver al inicio</a>.</p>
+        </div>
+    {{/with}}
+{{/if}}


### PR DESCRIPTION
This commit introduces a product detail page and resolves issues with product ID handling and visibility in the frontend.

Key changes:
- Standardized ID Handling: Ensured all persistence models (MongoDB, FS, Mem) and the API layer consistently use a string `id` property as the primary identifier. For MongoDB, `_id` is transformed to `id`, and `_id` and `__v` are removed from client-facing objects.
- Corrected ID in Home Page Links: Modified `controllers/frontend.js` to ensure the correct string `id` for each product is passed to `views/home.hbs`, fixing the previously broken "Más información" links.
- New Product Detail Route: Added a route `/productos/:id` in `routers/frontend.js`.
- New Controller Function: Implemented `renderProductDetail` in `controllers/frontend.js` to fetch a product by its ID and render its details. It handles cases where the product is found or not found, and manages other potential errors.
- New Handlebars View: Created `views/productDetail.hbs` to display the full details of a product, or an error message if applicable.
- Updated Comments: All new and modified code sections include detailed pedagogical comments in Spanish.

Testing confirmed that "Más información" links now function correctly, leading to the respective product detail pages, and that direct access to valid and invalid product detail URLs is handled gracefully.